### PR TITLE
Level 5: Summary 접기/더보기 기능 구현

### DIFF
--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/Util/Constants.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/Util/Constants.swift
@@ -22,10 +22,13 @@ enum Constants {
         static let textColorDarkGray: UIColor = .darkGray
     }
     
+    enum Color {
+        static let blue: UIColor = .systemBlue
+    }
+    
     enum Components {
         static let buttonTitleSize: CGFloat = 16
         static let buttonLength: CGFloat = 48
-        static let buttonColor: UIColor = .systemBlue
         
         static let imageViewWidth: CGFloat = 100
         static let imageViewHeight: CGFloat = imageViewWidth * 1.5

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/ChapterView.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/ChapterView.swift
@@ -6,10 +6,7 @@
 //
 
 import UIKit
-
-protocol CustomViewDelegate: AnyObject {
-    func didUpdateData(with chapters: [Chapter])
-}
+import SnapKit
 
 final class ChapterView: UIView {
     
@@ -50,7 +47,6 @@ final class ChapterView: UIView {
     }
     
     private func configSubview() {
-        
         addSubview(vStackView)
         
         [chaptersLabel]
@@ -61,7 +57,6 @@ final class ChapterView: UIView {
     }
     
     private func configUI() {
-        
         vStackView.axis = .vertical
         vStackView.spacing = Constants.Spacing.spacing8
         
@@ -70,20 +65,8 @@ final class ChapterView: UIView {
     }
     
     private func configAutoLayout() {
-        
         vStackView.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview()
-        }
-        
-        chaptersLabel.snp.makeConstraints {
-            $0.top.equalTo(vStackView.snp.top)
-            $0.horizontalEdges.equalToSuperview()
-        }
-        
-        chapterContents.forEach {
-            $0.snp.makeConstraints {
-                $0.leading.equalToSuperview()
-            }
+            $0.edges.equalToSuperview()
         }
     }
 }

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/HomeView.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/HomeView.swift
@@ -23,10 +23,6 @@ final class HomeView: UIView {
     private var contentSubView = UIView()
     private var vStackView = UIStackView()
     
-    // BOOK DATA
-    private var books: [Book] = Book.demo()
-    private var dataIndex: Int = .zero
-    
     // COMBINE
     private var subscriptions = Set<AnyCancellable>()
 
@@ -43,7 +39,6 @@ final class HomeView: UIView {
         super.init(frame: .zero)
         configSubview()
         configUI()
-        configData(with: books[dataIndex])
         configAutoLayout()
     }
     
@@ -61,7 +56,7 @@ final class HomeView: UIView {
         viewModel.books
             .receive(on: RunLoop.main)
             .sink { [unowned self] books in
-                self.dataIndex = Int.random(in: 0..<books.count)
+                let dataIndex = Int.random(in: 0..<books.count)
                 updateUI(books, dataIndex)
             }.store(in: &subscriptions)
     }
@@ -72,8 +67,7 @@ final class HomeView: UIView {
     /// Parameter: Update된 [BookResource] 데이터
     private func updateUI(_ books: [Book], _ dataIndex: Int) {
         // HomeView
-        titleLable.text = books[dataIndex].title
-        numberButton.setTitle("\(dataIndex + 1)", for: .normal)
+        configData(with: books[dataIndex], dataIndex)
         
         // InfoView
         infoView.configData(with: books[dataIndex], dataIndex)
@@ -192,9 +186,9 @@ final class HomeView: UIView {
         }
     }
     
-    private func configData(with book: Book) {
+    private func configData(with book: Book, _ dataIndex: Int) {
         
-        titleLable.text = books[dataIndex].title
+        titleLable.text = book.title
         numberButton.setTitle("\(dataIndex + 1)", for: .normal)
     }
 }

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/HomeView.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/HomeView.swift
@@ -57,7 +57,9 @@ final class HomeView: UIView {
             .receive(on: RunLoop.main)
             .sink { [weak self] books in
                 guard let self = self else { return }
-                let dataIndex = Int.random(in: 0..<books.count)
+                // Comment For Level 5
+                // let dataIndex = Int.random(in: 0..<books.count)
+                let dataIndex = 5
                 self.updateUI(books, dataIndex)
             }.store(in: &subscriptions)
     }
@@ -82,8 +84,8 @@ final class HomeView: UIView {
         summaryView.configData(with: "Summary", contentText: truncatedSummary)
         
         // MoreLessButton
-        moreLessButton.configData(with: books[dataIndex].summary)
         moreLessButton.delegate = summaryView
+        moreLessButton.configData(with: books[dataIndex].summary, dataIndex: dataIndex)
         
         // ChapterView
         chapterView.configData(with: books[dataIndex].chapters)
@@ -125,20 +127,21 @@ final class HomeView: UIView {
         numberButton.backgroundColor = Constants.Color.blue
         numberButton.layer.cornerRadius = Constants.Components.buttonLength / 2
         
+        // scrollview
         scrollview.isScrollEnabled = true
         scrollview.alwaysBounceVertical = true
         scrollview.showsVerticalScrollIndicator = false
         scrollview.showsHorizontalScrollIndicator = false
         scrollview.isDirectionalLockEnabled = true
         
+        // vStackView
         vStackView.axis = .vertical
         vStackView.spacing = Constants.Spacing.spacing24
     }
     
     private func configAutoLayout() {
         contentView.snp.makeConstraints {
-            $0.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
-            $0.top.equalTo(self.safeAreaLayoutGuide)
+            $0.top.horizontalEdges.equalTo(self.safeAreaLayoutGuide)
         }
         
         titleLable.snp.makeConstraints {
@@ -155,8 +158,7 @@ final class HomeView: UIView {
         
         scrollview.snp.makeConstraints {
             $0.top.equalTo(numberButton.snp.bottom).offset(Constants.Spacing.spacing10)
-            $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.horizontalEdges.bottom.equalToSuperview()
         }
         
         scrollview.contentLayoutGuide.snp.makeConstraints {
@@ -171,7 +173,6 @@ final class HomeView: UIView {
         vStackView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(Constants.Spacing.spacing10)
             $0.horizontalEdges.equalToSuperview().inset(Constants.Spacing.spacing25)
-            $0.bottom.equalToSuperview()
         }
     }
 }

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/InfoView.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/InfoView.swift
@@ -148,26 +148,3 @@ final class InfoView: UIView {
         }
     }
 }
-
-
-
-// MARK: - SwiftUI Preview
-
-struct ViewController_Preview3: PreviewProvider {
-    static var previews: some View {
-        ViewControllerRepresentable3()
-            .edgesIgnoringSafeArea(.all)
-        //            .previewDevice("iPhone 16 Pro")
-    }
-}
-
-struct ViewControllerRepresentable3: UIViewControllerRepresentable {
-    
-    func makeUIViewController(context: Context) -> ViewController {
-        return ViewController()
-    }
-    
-    func updateUIViewController(_ uiViewController: ViewController, context: Context) {
-        // 필요하면 업데이트 로직 추가
-    }
-}

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/InfoView.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/InfoView.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import SnapKit
-import SwiftUI
 
 final class InfoView: UIView {
     

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/InfoView.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/InfoView.swift
@@ -5,8 +5,9 @@
 //  Created by kingj on 4/1/25.
 //
 
-import Foundation
 import UIKit
+import SnapKit
+import SwiftUI
 
 final class InfoView: UIView {
     
@@ -138,21 +139,35 @@ final class InfoView: UIView {
         
         hStackView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(Constants.Components.imageViewHeight)
+            $0.verticalEdges.equalToSuperview()
         }
         
         imageview.snp.makeConstraints {
             $0.width.equalTo(Constants.Components.imageViewWidth)
             $0.height.equalTo(Constants.Components.imageViewHeight)
         }
-        
-        vStackView.snp.makeConstraints {
-            $0.top.equalTo(imageview.snp.top)
-        }
-        
-        titleLableSmall.snp.makeConstraints {
-            $0.top.equalTo(vStackView.snp.top)
-            $0.horizontalEdges.equalToSuperview()
-        }
+    }
+}
+
+
+
+// MARK: - SwiftUI Preview
+
+struct ViewController_Preview3: PreviewProvider {
+    static var previews: some View {
+        ViewControllerRepresentable3()
+            .edgesIgnoringSafeArea(.all)
+        //            .previewDevice("iPhone 16 Pro")
+    }
+}
+
+struct ViewControllerRepresentable3: UIViewControllerRepresentable {
+    
+    func makeUIViewController(context: Context) -> ViewController {
+        return ViewController()
+    }
+    
+    func updateUIViewController(_ uiViewController: ViewController, context: Context) {
+        // 필요하면 업데이트 로직 추가
     }
 }

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/LableContentView.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/LableContentView.swift
@@ -79,13 +79,13 @@ extension LableContentView {
 extension LableContentView: MoreLessButtonDelegate {
     
     func didMoreLessButtonToggle(toggle isExpanded: Bool, _ text: String) {
-        let titleLable = self.label.text ?? "[Nil] Summary"
+        let titleLable = self.label.text
         
         if isExpanded {
-            configData(with: titleLable, contentText: text)
+            configData(with: titleLable!, contentText: text)
         } else {
             let truncatedText = self.truncateWithEllipsis(from: text)
-            configData(with: titleLable, contentText: truncatedText)
+            configData(with: titleLable!, contentText: truncatedText)
         }
     }
 }

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/LableContentView.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/LableContentView.swift
@@ -5,8 +5,8 @@
 //  Created by kingj on 4/1/25.
 //
 
-import Foundation
 import UIKit
+import SnapKit
 
 final class LableContentView: UIView {
     
@@ -31,19 +31,16 @@ final class LableContentView: UIView {
     // MARK: - Methods
     
     func configData(with lableText: String, contentText: String) {
-        
         label.text = "\(lableText)"
         content.text = "\(contentText)"
     }
     
     private func configSubview() {
-        
         [label, content]
             .forEach { addSubview($0) }
     }
     
     private func configUI() {
-        
         // label
         label.font = .systemFont(ofSize: Constants.Text.textSize18, weight: .bold)
         label.textColor = Constants.Text.textColorDefault
@@ -52,20 +49,43 @@ final class LableContentView: UIView {
         content.font = .systemFont(ofSize: Constants.Text.textSize14)
         content.textColor = Constants.Text.textColorDarkGray
         content.numberOfLines = .zero
+        
     }
     
     private func configAutoLayout() {
-        
         label.snp.makeConstraints {
-            $0.leading.equalToSuperview()
-            $0.top.equalToSuperview().offset(Constants.Spacing.spacing5)
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
         }
         
         content.snp.makeConstraints {
             $0.top.equalTo(label.snp.bottom).offset(Constants.Spacing.spacing8)
             $0.horizontalEdges.equalToSuperview()
-            $0.leading.equalTo(label.snp.leading)
-            $0.bottom.equalToSuperview().inset(Constants.Spacing.spacing5)
+            $0.bottom.equalToSuperview().offset(Constants.Spacing.spacing8)
+        }
+    }
+}
+
+extension LableContentView {
+    
+    func truncateWithEllipsis(from text: String) -> String {
+        if text.count >= 450 {
+            let index = text.index(text.startIndex, offsetBy: 450)
+            return String(text[..<index]) + "..."
+        } else { return text }
+    }
+}
+
+extension LableContentView: MoreLessButtonDelegate {
+    
+    func didMoreLessButtonToggle(toggle isExpanded: Bool, _ text: String) {
+        let titleLable = self.label.text ?? "[Nil] Summary"
+        
+        if isExpanded {
+            configData(with: titleLable, contentText: text)
+        } else {
+            let truncatedText = self.truncateWithEllipsis(from: text)
+            configData(with: titleLable, contentText: truncatedText)
         }
     }
 }

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/MoreLessButton.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/MoreLessButton.swift
@@ -5,4 +5,72 @@
 //  Created by kingj on 4/2/25.
 //
 
-import Foundation
+import UIKit
+import SnapKit
+
+final class MoreLessButton: UIView {
+    
+    // MARK: - Delegates
+    
+    weak var delegate: MoreLessButtonDelegate?
+
+    // MARK: - Components
+
+    var button = UIButton()
+    
+    private var isExpanded: Bool = false
+    private var receivedText: String!
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        configSubview()
+        configUI()
+        configAutoLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Methods
+    
+    func configData(with text: String) {
+        self.receivedText = text
+        button.isHidden = text.count < 450
+        configButtonTitle()
+    }
+    
+    private func configButtonTitle() {
+        if isExpanded {
+            button.setTitle("접기", for: .normal)
+        } else {
+            button.setTitle("더 보기", for: .normal)
+        }
+    }
+    
+    @objc
+    private func buttonToggled() {
+        isExpanded.toggle()
+        configButtonTitle()
+        delegate?.didMoreLessButtonToggle(toggle: isExpanded, receivedText)
+    }
+    
+    private func configSubview() {
+        addSubview(button)
+        bringSubviewToFront(button)
+    }
+    
+    private func configUI() {
+        button.setTitleColor(Constants.Color.blue, for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 14)
+        button.addTarget(self, action: #selector(buttonToggled), for: .touchUpInside)
+    }
+    
+    private func configAutoLayout() {
+        button.snp.makeConstraints {
+            $0.verticalEdges.trailing.equalToSuperview()
+        }
+    }
+}

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/MoreLessButton.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/MoreLessButton.swift
@@ -1,0 +1,8 @@
+//
+//  MoreLessButton.swift
+//  HarryPotterSeriesHakyung
+//
+//  Created by kingj on 4/2/25.
+//
+
+import Foundation

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/MoreLessButton.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/MoreLessButton.swift
@@ -18,8 +18,9 @@ final class MoreLessButton: UIView {
 
     var button = UIButton()
     
-    private var isExpanded: Bool = false
+    private var isExpanded: Bool!
     private var receivedText: String!
+    private var receivedDataIndex: String!
     
     // MARK: - Init
     
@@ -36,17 +37,34 @@ final class MoreLessButton: UIView {
     
     // MARK: - Methods
     
-    func configData(with text: String) {
+    func configData(with text: String, dataIndex: Int) {
         self.receivedText = text
+        self.receivedDataIndex = "\(dataIndex)"
+        
         button.isHidden = text.count < 450
+        
+        getIsExpandedState()
         configButtonTitle()
+        delegate?.didMoreLessButtonToggle(toggle: isExpanded, receivedText)
     }
     
+    // UserDefaults
+    // Key: Book index, value: [isExpended state]
     private func configButtonTitle() {
         if isExpanded {
             button.setTitle("접기", for: .normal)
         } else {
             button.setTitle("더 보기", for: .normal)
+        }
+        UserDefaults.standard.set([isExpanded], forKey: self.receivedDataIndex)
+    }
+    
+    private func getIsExpandedState() {
+        if let value = UserDefaults.standard.array(forKey: self.receivedDataIndex) as? [Bool] {
+            isExpanded = value.first!
+        } else { // 앱 처음 실행
+            isExpanded = false
+            UserDefaults.standard.set([isExpanded], forKey: self.receivedDataIndex)
         }
     }
     

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/MoreLessButtonDelegate.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/MoreLessButtonDelegate.swift
@@ -5,4 +5,8 @@
 //  Created by kingj on 4/2/25.
 //
 
-import Foundation
+import UIKit
+
+protocol MoreLessButtonDelegate: AnyObject {
+    func didMoreLessButtonToggle(toggle isExpanded: Bool, _ text: String) 
+}

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/MoreLessButtonDelegate.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/MoreLessButtonDelegate.swift
@@ -1,0 +1,8 @@
+//
+//  MoreLessButtonDelegate.swift
+//  HarryPotterSeriesHakyung
+//
+//  Created by kingj on 4/2/25.
+//
+
+import Foundation

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/ViewController.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/View/ViewController.swift
@@ -7,24 +7,25 @@
 
 import UIKit
 import Combine
+import SnapKit
 
 class ViewController: UIViewController {
     
     // MARK: - Properties
     
-    private let harryPotterView = HomeView()
-    private var harryPotterViewModel: HarryPotterViewModel!
+    private let homeView = HomeView()
+    private var homeViewModel: HomeViewModel!
     
     // MARK: - Lifecycle Methods
     
     override func loadView() {
         super.loadView()
-        view = harryPotterView
+        view = homeView
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        harryPotterViewModel = HarryPotterViewModel(books: Book.demo())
+        homeViewModel = HomeViewModel(books: Book.demo())
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -39,10 +40,10 @@ class ViewController: UIViewController {
     }
     
     private func checkBookResource() {
-        let result = harryPotterViewModel.appDidRun()
+        let result = homeViewModel.appDidRun()
         switch result {
-        case .success(let data):
-            harryPotterView.updateViewData(from: harryPotterViewModel)
+        case .success(_):
+            homeView.updateViewData(from: homeViewModel)
             
         case .failure(let error):
             let alert = UIAlertController(

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/ViewModel/HomeViewModel.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/ViewModel/HomeViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Combine
 
-final class HarryPotterViewModel {
+final class HomeViewModel {
     
     // MARK: - Properties
     

--- a/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/ViewModel/HomeViewModel.swift
+++ b/HarryPotterSeriesHakyung/HarryPotterSeriesHakyung/ViewModel/HomeViewModel.swift
@@ -23,7 +23,7 @@ final class HomeViewModel {
     
     // MARK: - Methods
     
-    // Input: User Action(= App Runed)
+    // Input: User Action(= App Did Run)
     func appDidRun() -> Result<[Book], ServiceError> {
         let result = DataService.fetchBooks(from: "data")
         switch result {


### PR DESCRIPTION
 ## ✨ Level 5: Summary 접기/더보기 기능 구현
- 이슈 번호: #17  #22 
- 글자수가 450자 이상인 경우 … 말줄임표 표시 및 더보기 버튼 표시
   - 예외사항
     - 2권(시리즈 두번째)의 요약 내용은 글자수가 450자 미만이므로 더보기 버튼이 표시되지 않아야 한다.
- 더보기 버튼을 누르면 요약 텍스트 전체가 표시되고 더보기 버튼은 접기 버튼으로 변경
   - 더보기 버튼을 눌러 Summary를 펼친 상태로 앱을 종료했다면, 앱을 다시 실행했을 때 펼쳐진 상태로 표시되어 있어야 한다.
   - 반대로 접기버튼을 눌러 접은 상태로 종료했다면 앱 종료 후 다시 실행했을 때 접은 상태로 표시되어 있어야 한다.

---

## 🐛 [Bug] Level 4: `dedicationView` 제약 조건 충돌, 스크롤 이슈 해결
- 이슈 번호: #18 
- `dedicationView` 제약 조건을 포함하여, 제약 조건에서 발생하는 모든 충돌 (warning) 해결
- `UIScrollView`의 `height`이 애매모호하여 스크롤 되지 않았던 이슈 해결

---

## ♻️ Level 2, 3, 4: `HomView`에서 `Book`데이터 초기화 중복 문제 해결
- 이슈 번호: #20 
- 위치: `HomeView.swift`
- 기존에 `전역변수`로 선언했던 아래 코드를 삭제
    ```swift
    private var books: [Book] = Book.demo()
    private var dataIndex: Int!
    ```
- 데이터 구성을 위해 분리시킨 `configData(with:_:)` 메소드를 `updateUI(_:_:)` 메소드에 넣고,
  `Publisher`인 `Book`데이터가 업데이트 되는 경우 호출되도록 변경
   - `전역변수` 초기화가 필요 없는 이유는, 사용자가 앱을 진입하는 시점에서 데이터를 읽어오고 
     **성공시**, 읽은 데이터로 `UI`에 파싱 시켜주고 / **실패시**, `Alert`와 함께 초기화용 `demo()` 데이터를 넣어주기 때문에
     어떠한 경우이던지 데이터가 비어있을 경우가 존재하지 않는다. 
      ```swift
      private func configData(with book: Book, _ dataIndex: Int) {
          titleLable.text = book.title
          numberButton.setTitle("\(dataIndex + 1)", for: .normal)
      }
      ```
   - 따라서, 별도의 초기화는 필요 없고, `override init(frame: )` 메소드에서 `configData(with:_:)`를 호출시켰던 코드도 삭제한다.